### PR TITLE
release/2.0.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects{
     group = "com.kalimero2.team"
-    version = "2.0.3"
+    version = "2.0.4-SNAPSHOT"
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects{
     group = "com.kalimero2.team"
-    version = "2.0.4-SNAPSHOT"
+    version = "2.0.4"
 }
 
 java {

--- a/claims-api/src/main/java/com/kalimero2/team/claims/api/ClaimsApi.java
+++ b/claims-api/src/main/java/com/kalimero2/team/claims/api/ClaimsApi.java
@@ -95,13 +95,13 @@ public interface ClaimsApi {
 
 
     /**
-     * Gets all claims in a world
+     * Gets all claims in a world. (If claim isn't loaded, members and interactables will be empty)
      *
      * @param world the world to get the claims from
      * @return all claims in specified world
      */
+    @Deprecated(forRemoval = true)
     List<Claim> getClaims(World world);
-
 
     /**
      * Gets the claims of a group

--- a/claims-api/src/main/java/com/kalimero2/team/claims/api/flag/ClaimsFlags.java
+++ b/claims-api/src/main/java/com/kalimero2/team/claims/api/flag/ClaimsFlags.java
@@ -10,6 +10,7 @@ public final class ClaimsFlags {
     public static final Flag ITEM_PICKUP = register("item_pickup", true, true);
     public static final Flag NO_PHYSICS = register("no_physics", false, true);
     public static final Flag NO_ENTER_MESSAGE = register("no_enter_message", false, true);
+    public static final Flag MONSTER_SPAWNING = register("monster_spawning", true, true);
     /**
      * Currently defaults to true,but will be changed to false in the future, when expiration is implemented
      */

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/PaperClaims.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/PaperClaims.java
@@ -7,6 +7,7 @@ import com.kalimero2.team.claims.api.flag.ClaimsFlags;
 import com.kalimero2.team.claims.paper.listener.ChunkProtectionListener;
 import com.kalimero2.team.claims.paper.listener.ExplosionListener;
 import com.kalimero2.team.claims.paper.listener.ItemListener;
+import com.kalimero2.team.claims.paper.listener.MonsterSpawnListener;
 import com.kalimero2.team.claims.paper.listener.PhysicsListener;
 import com.kalimero2.team.claims.paper.listener.PlayerMoveListener;
 import com.kalimero2.team.claims.paper.storage.Storage;
@@ -47,6 +48,7 @@ public class PaperClaims extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new ExplosionListener(api), this); // Flag: EXPLOSIONS
         getServer().getPluginManager().registerEvents(new PhysicsListener(api), this); // Flag: NO_PHYSICS
         getServer().getPluginManager().registerEvents(new ItemListener(api), this); // Flag: ITEM_DROP, ITEM_PICKUP
+        getServer().getPluginManager().registerEvents(new MonsterSpawnListener(api), this); // Flag: MONSTER_SPAWNING
 
         chunkBorders = new ChunkBorders(this);
 

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/claim/ClaimManager.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/claim/ClaimManager.java
@@ -19,11 +19,11 @@ import com.kalimero2.team.claims.api.interactable.MaterialInteractable;
 import com.kalimero2.team.claims.paper.PaperClaims;
 import com.kalimero2.team.claims.paper.command.ChunkAdminCommands;
 import com.kalimero2.team.claims.paper.storage.Storage;
-import com.kalimero2.team.claims.paper.storage.StoredMaterialInteractable;
 import com.kalimero2.team.claims.paper.storage.StoredClaim;
 import com.kalimero2.team.claims.paper.storage.StoredEntityInteractable;
 import com.kalimero2.team.claims.paper.storage.StoredGroup;
 import com.kalimero2.team.claims.paper.storage.StoredGroupMember;
+import com.kalimero2.team.claims.paper.storage.StoredMaterialInteractable;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -152,7 +152,7 @@ public class ClaimManager implements ClaimsApi, Listener {
     }
 
     @Override
-    public int getClaimAmount(Group group){
+    public int getClaimAmount(Group group) {
         return storage.getClaimAmount(group);
     }
 
@@ -224,7 +224,7 @@ public class ClaimManager implements ClaimsApi, Listener {
 
     private void refreshGroupInLoadedClaims(Group group) {
         loadedClaims.values().forEach(claim -> {
-            if(claim != null){
+            if (claim != null) {
                 if (claim.getOwner().equals(group)) {
                     StoredClaim storedClaim = StoredClaim.cast(claim);
                     storedClaim.setOwner(group);
@@ -397,7 +397,7 @@ public class ClaimManager implements ClaimsApi, Listener {
     @Override
     public void setOwner(Chunk chunk, Group target) {
         Claim claim2 = getClaim(chunk);
-        if(claim2 != null){
+        if (claim2 != null) {
             Group owner = claim2.getOwner();
             new ClaimOwnerChangeEvent(chunk, owner, target, claim2).callEvent();
         }
@@ -417,12 +417,12 @@ public class ClaimManager implements ClaimsApi, Listener {
         Group playerGroup = storage.getPlayerGroup(event.getPlayer());
         if (playerGroup == null) {
             storage.createPlayerGroup(event.getPlayer(), plugin.getConfig().getInt("claims.max-claims"));
-        }else {
+        } else {
             getGroups(event.getPlayer()).forEach(group -> {
                 storage.updateLastSeen(group);
                 refreshGroupInLoadedClaims(group);
             });
-            if(!event.getPlayer().getName().equals(playerGroup.getName())){
+            if (!event.getPlayer().getName().equals(playerGroup.getName())) {
                 storage.renameGroup(playerGroup, event.getPlayer().getName());
                 plugin.getLogger().info("Renamed PlayerGroup " + playerGroup.getName() + " to " + event.getPlayer().getName());
             }
@@ -448,7 +448,10 @@ public class ClaimManager implements ClaimsApi, Listener {
         if (loadedClaims.containsKey(event.getChunk())) {
             Claim claim = loadedClaims.get(event.getChunk());
             if (claim != null) {
-                storage.saveClaim(claim);
+                boolean saved = storage.saveClaim(claim);
+                if (!saved) {
+                    plugin.getLogger().severe("Could not save claim " + claim.getChunk().getX() + " " + claim.getChunk().getZ());
+                }
             }
             loadedClaims.remove(event.getChunk());
         }
@@ -459,7 +462,10 @@ public class ClaimManager implements ClaimsApi, Listener {
         plugin.getLogger().info("Saving all claims... (This may take a while)");
         for (Claim claim : loadedClaims.values()) {
             if (claim != null) {
-                storage.saveClaim(claim);
+                boolean saved = storage.saveClaim(claim);
+                if (!saved) {
+                    plugin.getLogger().severe("Could not save claim " + claim.getChunk().getX() + " " + claim.getChunk().getZ());
+                }
             }
         }
         loadedClaims.clear();

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/claim/ClaimManager.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/claim/ClaimManager.java
@@ -80,16 +80,18 @@ public class ClaimManager implements ClaimsApi, Listener {
 
     @Override
     public boolean getFlagState(Claim claim, Flag flag) {
+        if (flag == null) throw new IllegalArgumentException("Flag cannot be null");
         if (!registeredFlags.containsValue(flag)) {
-            throw new IllegalArgumentException("Flag is not registered");
+            throw new IllegalArgumentException("Flag (" + flag.getKeyString() + ") is not registered");
         }
         return Objects.requireNonNullElseGet(claim.getFlags().get(flag), flag::getDefaultState);
     }
 
     @Override
     public boolean setFlagState(Claim claim, Flag flag, boolean state) {
+        if (flag == null) throw new IllegalArgumentException("Flag cannot be null");
         if (!registeredFlags.containsValue(flag)) {
-            throw new IllegalArgumentException("Flag is not registered");
+            throw new IllegalArgumentException("Flag (" + flag.getKeyString() + ") is not registered");
         }
 
         FlagSetEvent event = new FlagSetEvent(claim, flag, state);
@@ -107,8 +109,9 @@ public class ClaimManager implements ClaimsApi, Listener {
 
     @Override
     public boolean unsetFlagState(Claim claim, Flag flag) {
+        if (flag == null) throw new IllegalArgumentException("Flag cannot be null");
         if (!registeredFlags.containsValue(flag)) {
-            throw new IllegalArgumentException("Flag is not registered");
+            throw new IllegalArgumentException("Flag (" + flag.getKeyString() + ") is not registered");
         }
         FlagUnsetEvent event = new FlagUnsetEvent(claim, flag);
         if (event.callEvent()) {
@@ -128,6 +131,7 @@ public class ClaimManager implements ClaimsApi, Listener {
         if (loadedClaims.containsKey(chunk)) {
             return loadedClaims.get(chunk);
         }
+
         Claim claimData = storage.getClaimData(chunk);
         loadedClaims.put(chunk, claimData);
         return claimData;

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/claim/ClaimManager.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/claim/ClaimManager.java
@@ -134,11 +134,9 @@ public class ClaimManager implements ClaimsApi, Listener {
     }
 
     @Override
+    @SuppressWarnings("removal")
     public List<Claim> getClaims(World world) {
-        List<Claim> claims = storage.getClaims(world);
-        // Replace all claims with loaded claims if they are loaded
-        claims.replaceAll(claim -> loadedClaims.containsValue(claim) ? loadedClaims.get(claim.getChunk()) : claim);
-        return claims;
+        return storage.getClaims(world);
     }
 
     @Override
@@ -463,5 +461,9 @@ public class ClaimManager implements ClaimsApi, Listener {
         loadedClaims.clear();
         storage.shutdown();
         plugin.getLogger().info("Saved all claims in " + (System.nanoTime() - startTime) / 1000000 + "ms");
+    }
+
+    public HashMap<Chunk, Claim> getLoadedClaims() {
+        return loadedClaims;
     }
 }

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/command/ChunkAdminCommands.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/command/ChunkAdminCommands.java
@@ -265,10 +265,11 @@ public class ChunkAdminCommands extends CommandHandler {
         int limit = context.get("limit");
 
         int maxClaims = target.getMaxClaims();
-        api.setMaxClaims(target, maxClaims + limit);
+        int newLimit = maxClaims + limit;
+        api.setMaxClaims(target, newLimit);
 
         plugin.getMessageUtil().sendMessage(context.getSender(), "chunk.admin.limit.add",
-                Placeholder.unparsed("count", String.valueOf(limit)),
+                Placeholder.unparsed("count", String.valueOf(newLimit)),
                 Placeholder.unparsed("old_count", String.valueOf(oldLimit)),
                 Placeholder.unparsed("target", target.getName())
         );

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/command/ChunkBorderCommand.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/command/ChunkBorderCommand.java
@@ -20,11 +20,11 @@ public class ChunkBorderCommand extends CommandHandler {
 
     private void toggleBorder(CommandContext<CommandSender> context) {
         if (context.getSender() instanceof Player player) {
-            if (ChunkBorders.show_border.contains(player)) {
+            if (ChunkBorders.show_border.containsKey(player)) {
                 ChunkBorders.show_border.remove(player);
                 plugin.getMessageUtil().sendMessage(player, "chunkborder.off");
             } else {
-                ChunkBorders.show_border.add(player);
+                ChunkBorders.show_border.put(player, player.getChunk());
                 plugin.getMessageUtil().sendMessage(player, "chunkborder.on");
             }
         }

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/listener/ChunkProtectionListener.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/listener/ChunkProtectionListener.java
@@ -497,7 +497,9 @@ public class ChunkProtectionListener implements Listener {
     public void onBlockFertilize(BlockFertilizeEvent event) {
         Chunk originChunk = event.getBlock().getChunk();
 
-        if (shouldCancel(event.getPlayer(), originChunk)) {
+        Player player = event.getPlayer();
+
+        if (player != null && shouldCancel(player, originChunk)) {
             event.setCancelled(true);
         }
 

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/listener/MonsterSpawnListener.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/listener/MonsterSpawnListener.java
@@ -1,0 +1,31 @@
+package com.kalimero2.team.claims.paper.listener;
+
+import com.kalimero2.team.claims.api.ClaimsApi;
+import com.kalimero2.team.claims.api.flag.ClaimsFlags;
+import org.bukkit.entity.Monster;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntitySpawnEvent;
+
+public class MonsterSpawnListener implements Listener {
+
+    private final ClaimsApi api;
+
+    public MonsterSpawnListener(ClaimsApi api) {
+        this.api = api;
+    }
+
+    @EventHandler
+    public void onMobSpawn(EntitySpawnEvent event) {
+
+        if (api.getClaim(event.getEntity().getChunk()) != null) {
+            if (event.getEntity() instanceof Monster) {
+                boolean mobSpawning = api.getFlagState(api.getClaim(event.getEntity().getChunk()), ClaimsFlags.MONSTER_SPAWNING);
+                if (!mobSpawning) {
+                    event.setCancelled(true);
+                }
+            }
+        }
+    }
+
+}

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/storage/Storage.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/storage/Storage.java
@@ -301,7 +301,11 @@ public class Storage {
                 String flagIdentifier = resultSet.getString("FLAG_IDENTIFIER");
                 boolean state = resultSet.getBoolean("STATE");
                 Flag flag = ClaimsApi.getApi().getFlag(NamespacedKey.fromString(flagIdentifier));
-                flags.put(flag, state);
+                if (flag == null) {
+                    plugin.getLogger().severe("Flag " + flagIdentifier + " not found for claim " + claimId);
+                } else {
+                    flags.put(flag, state);
+                }
             }
             resultSet.close();
 

--- a/claims-paper/src/main/java/com/kalimero2/team/claims/paper/util/ChunkBorders.java
+++ b/claims-paper/src/main/java/com/kalimero2/team/claims/paper/util/ChunkBorders.java
@@ -1,32 +1,41 @@
 package com.kalimero2.team.claims.paper.util;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.Plugin;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 
 public class ChunkBorders implements Listener {
 
-    public static ArrayList<Player> show_border = new ArrayList<>();
+    public static HashMap<Player, Chunk> show_border = new HashMap<>();
 
     public ChunkBorders(Plugin plugin) {
-        Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, () -> show_border.forEach(ChunkBorders::render_particles), 0L, 1L);
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        plugin.getServer().getScheduler().scheduleSyncRepeatingTask(plugin, () -> show_border.forEach(ChunkBorders::render_particles), 0L, 5L);
     }
 
-    private static void render_particles(Player player) {
-        Chunk chunk = player.getLocation().getChunk();
+    private static void render_particles(Player player, Chunk chunk) {
         for (int i = 0; i < 16; i++) {
             player.spawnParticle(Particle.NOTE, chunk.getBlock(i, (int) player.getLocation().getY() + 1, 0).getLocation(), 1);
             player.spawnParticle(Particle.NOTE, chunk.getBlock(i, (int) player.getLocation().getY() + 1, 15).getLocation().add(0, 0, 1), 1);
             player.spawnParticle(Particle.NOTE, chunk.getBlock(0, (int) player.getLocation().getY() + 1, i).getLocation(), 1);
             player.spawnParticle(Particle.NOTE, chunk.getBlock(15, (int) player.getLocation().getY() + 1, i).getLocation().add(1, 0, 0), 1);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        if (show_border.containsKey(event.getPlayer())) {
+            if (!show_border.get(event.getPlayer()).equals(event.getTo().getChunk())) {
+                show_border.put(event.getPlayer(), event.getTo().getChunk());
+            }
         }
     }
 

--- a/claims-squaremap-integration/build.gradle.kts
+++ b/claims-squaremap-integration/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
 bukkit {
     main = "com.kalimero2.team.claims.squaremap.SquaremapClaims"
     apiVersion = "1.20"
-    load = BukkitPluginDescription.PluginLoadOrder.POSTWORLD
+    load = BukkitPluginDescription.PluginLoadOrder.STARTUP
     authors = listOf("byquanton")
     depend = listOf("squaremap","claims-paper")
 }


### PR DESCRIPTION
- bump version to next snapshot
- fix: Dispender Blocks with Bone Meal can't spread moss Don't cancel the spread event if it isn't caused by a player
- fix: /chunk limit add Command message
- Performance improvements for getClaims(World world) method
- Improve ChunkBorder performance
- Add Monster-Spawn Flag
- Flags are registered too late
- Make Flags more robust
- Add logging if saving a claim fails
- Release 2.0.4
